### PR TITLE
feat: Add Tapogo client for KLAP management

### DIFF
--- a/api/v1alpha1/integrations_types.go
+++ b/api/v1alpha1/integrations_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 // --
 type TapoSmartPlugSpec struct {
+	Client  string `yaml:"client"`
 	Address string `yaml:"address"`
 	Auth    struct {
 		Username string `yaml:"username" env:"TAPO_SMARTPLUG_USERNAME"`

--- a/config/samples/autoheater.yaml
+++ b/config/samples/autoheater.yaml
@@ -59,7 +59,13 @@ spec:
 
       # Data for sending the events to TAPO P1XX devices (p100, p110, etc)
       tapoSmartPlug:
-        address: "192.168.1.100"
+        # (Optional) protocol used to communicate with Tapo plugs.
+        # TPLink tends to change completely the protocol from time to time.
+        # legacy: is used for older firmware versions and supports 'securePassthrough' protocol
+        # modern: (default) is used for newer firmware versions and supports 'KLAP' protocol
+        client: modern
+
+        address: "192.168.1.109"
 
         # (Optional) username and password for auth. It's the same used to access the app (it's accessed locally, but
         # Tapo devices are configured that way when they are set up)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/achetronic/autoheater
 go 1.21
 
 require (
+	github.com/achetronic/tapogo v0.1.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/caarlos0/env/v9 v9.0.0
 	github.com/richardjennings/tapo v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/achetronic/tapogo v0.1.1 h1:HbTRMUCl6rnd7Q//R/RSfT9uvJHz2ynFqyb2upbdUAw=
+github.com/achetronic/tapogo v0.1.1/go.mod h1:DVflSfbePg4SAjRy0aeMYJ0vj4Pjesw5sw6y4yP0f8w=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=


### PR DESCRIPTION
Description:
* Add [Tapogo](https://github.com/achetronic/tapogo) client to be able to manage KLAP
* Add new config field to switch from old client to new one